### PR TITLE
add trait command

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ php artisan beyond:make:rule Admin/Users/IsAdminRule
 This command will create a new trait class inside your application.
 
 ```bash
-php artisan beyond:make:trait Users/HasActivationCodeTrait
+php artisan beyond:make:trait HasActivationCodeTrait
 ```
 
 **Options**
@@ -350,7 +350,6 @@ php artisan beyond:make:trait Users/HasActivationCodeTrait
 | Name        | Description                                       |
 |-------------|---------------------------------------------------|
 | `--force`   | Create the trait even if the trait already exists |
-| `--support` | Will create a trait in Support namespace          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -347,10 +347,10 @@ php artisan beyond:make:trait Users/HasActivationCodeTrait
 
 **Options**
 
-| Name        | Description                                      |
-|-------------|--------------------------------------------------|
-| `--force`   | Create the trait even if the rule already exists |
-| `--support` | Will create a trait in Support namespace         |
+| Name        | Description                                       |
+|-------------|---------------------------------------------------|
+| `--force`   | Create the trait even if the trait already exists |
+| `--support` | Will create a trait in Support namespace          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,23 @@ php artisan beyond:make:rule Admin/Users/IsAdminRule
 
 ---
 
+#### `beyond:make:trait`
+
+This command will create a new trait class inside your application.
+
+```bash
+php artisan beyond:make:trait Users/HasActivationCodeTrait
+```
+
+**Options**
+
+| Name          | Description                              |
+|---------------|------------------------------------------|
+| `--overwrite` | Will overwrite the file if it exists     |
+| `--support`   | Will create a trait in Support namespace |
+
+---
+
 #### `beyond:make:provider`
 
 This command will create a new service provider class.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ inspired application.
 We try to implement commands as near as possible on their original `make` counterparts.
 
 ## Upgrade Guide
-Please read our [Upgrade Guide](UPGRADE.md) in case you are using version 3.x. 
+Please read our [Upgrade Guide](UPGRADE.md) in case you are using version 3.x.
 
 ## Installation
 
@@ -347,10 +347,10 @@ php artisan beyond:make:trait Users/HasActivationCodeTrait
 
 **Options**
 
-| Name          | Description                              |
-|---------------|------------------------------------------|
-| `--overwrite` | Will overwrite the file if it exists     |
-| `--support`   | Will create a trait in Support namespace |
+| Name        | Description                                      |
+|-------------|--------------------------------------------------|
+| `--force`   | Create the trait even if the rule already exists |
+| `--support` | Will create a trait in Support namespace         |
 
 ---
 

--- a/src/Commands/MakeTraitCommand.php
+++ b/src/Commands/MakeTraitCommand.php
@@ -19,8 +19,6 @@ class MakeTraitCommand extends BaseCommand
             $force = $this->option('force');
 
             $stub = $support ? 'trait.support.stub' : 'trait.stub';
-            $directory = $support ? 'Packages/Laravel/Traits' : 'Traits';
-
             $schema = $support ?
                 (new AppNameSchemaResolver($this, $name, support: $support))->handle() :
                 (new DomainNameSchemaResolver($this, $name))->handle()
@@ -28,7 +26,7 @@ class MakeTraitCommand extends BaseCommand
 
             beyond_copy_stub(
                 $stub,
-                $schema->path($directory),
+                $schema->path('Traits'),
                 [
                     '{{ namespace }}' => $schema->namespace(),
                     '{{ className }}' => $schema->className(),

--- a/src/Commands/MakeTraitCommand.php
+++ b/src/Commands/MakeTraitCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Regnerisch\LaravelBeyond\Commands;
+
+use Regnerisch\LaravelBeyond\Resolvers\AppNameSchemaResolver;
+
+class MakeTraitCommand extends BaseCommand
+{
+    protected $signature = 'beyond:make:trait {name?} {--support} {--overwrite}';
+
+    protected $description = 'Make a new trait';
+
+    public function handle(): void
+    {
+        try {
+            $name = $this->argument('name');
+            $support = $this->option('support');
+            $overwrite = $this->option('overwrite');
+
+            $stub = $support ? 'trait.support.stub' : 'trait.stub';
+            $directory = $support ? 'Packages/Laravel/Traits' : 'Traits';
+
+            $schema = (new AppNameSchemaResolver($this, $name, support: $support))->handle();
+
+            beyond_copy_stub(
+                $stub,
+                $schema->path($directory),
+                [
+                    '{{ namespace }}' => $schema->namespace(),
+                    '{{ className }}' => $schema->className(),
+                ],
+                $overwrite
+            );
+
+            $this->components->info('Trait created.');
+        } catch (\Exception $exception) {
+            $this->components->error($exception->getMessage());
+        }
+    }
+}

--- a/src/Commands/MakeTraitCommand.php
+++ b/src/Commands/MakeTraitCommand.php
@@ -7,7 +7,7 @@ use Regnerisch\LaravelBeyond\Resolvers\DomainNameSchemaResolver;
 
 class MakeTraitCommand extends BaseCommand
 {
-    protected $signature = 'beyond:make:trait {name?} {--support} {--force}';
+    protected $signature = 'beyond:make:trait {name?} {--force}';
 
     protected $description = 'Make a new trait';
 
@@ -15,20 +15,14 @@ class MakeTraitCommand extends BaseCommand
     {
         try {
             $name = $this->argument('name');
-            $support = $this->option('support');
             $force = $this->option('force');
 
-            $stub = $support ? 'trait.support.stub' : 'trait.stub';
-            $schema = $support ?
-                (new AppNameSchemaResolver($this, $name, support: $support))->handle() :
-                (new DomainNameSchemaResolver($this, $name))->handle()
-            ;
+            $schema = (new AppNameSchemaResolver($this, $name, support: true))->handle();
 
             beyond_copy_stub(
-                $stub,
+                'trait.stub',
                 $schema->path('Traits'),
                 [
-                    '{{ namespace }}' => $schema->namespace(),
                     '{{ className }}' => $schema->className(),
                 ],
                 $force

--- a/src/Commands/MakeTraitCommand.php
+++ b/src/Commands/MakeTraitCommand.php
@@ -3,6 +3,7 @@
 namespace Regnerisch\LaravelBeyond\Commands;
 
 use Regnerisch\LaravelBeyond\Resolvers\AppNameSchemaResolver;
+use Regnerisch\LaravelBeyond\Resolvers\DomainNameSchemaResolver;
 
 class MakeTraitCommand extends BaseCommand
 {
@@ -20,7 +21,10 @@ class MakeTraitCommand extends BaseCommand
             $stub = $support ? 'trait.support.stub' : 'trait.stub';
             $directory = $support ? 'Packages/Laravel/Traits' : 'Traits';
 
-            $schema = (new AppNameSchemaResolver($this, $name, support: $support))->handle();
+            $schema = $support ?
+                (new AppNameSchemaResolver($this, $name, support: $support))->handle() :
+                (new DomainNameSchemaResolver($this, $name))->handle()
+            ;
 
             beyond_copy_stub(
                 $stub,

--- a/src/Commands/MakeTraitCommand.php
+++ b/src/Commands/MakeTraitCommand.php
@@ -7,7 +7,7 @@ use Regnerisch\LaravelBeyond\Resolvers\DomainNameSchemaResolver;
 
 class MakeTraitCommand extends BaseCommand
 {
-    protected $signature = 'beyond:make:trait {name?} {--support} {--overwrite}';
+    protected $signature = 'beyond:make:trait {name?} {--support} {--force}';
 
     protected $description = 'Make a new trait';
 
@@ -16,7 +16,7 @@ class MakeTraitCommand extends BaseCommand
         try {
             $name = $this->argument('name');
             $support = $this->option('support');
-            $overwrite = $this->option('overwrite');
+            $force = $this->option('force');
 
             $stub = $support ? 'trait.support.stub' : 'trait.stub';
             $directory = $support ? 'Packages/Laravel/Traits' : 'Traits';
@@ -33,7 +33,7 @@ class MakeTraitCommand extends BaseCommand
                     '{{ namespace }}' => $schema->namespace(),
                     '{{ className }}' => $schema->className(),
                 ],
-                $overwrite
+                $force
             );
 
             $this->components->info('Trait created.');

--- a/stubs/trait.stub
+++ b/stubs/trait.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace Domain\{{ namespace }}\Traits;
+namespace Support\Traits;
 
 trait {{ className }}
 {

--- a/stubs/trait.stub
+++ b/stubs/trait.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\{{ namespace }}\Traits;
+namespace Domain\{{ namespace }}\Traits;
 
 trait {{ className }}
 {

--- a/stubs/trait.stub
+++ b/stubs/trait.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\{{ namespace }}\Traits;
+
+trait {{ className }}
+{
+
+}

--- a/stubs/trait.support.stub
+++ b/stubs/trait.support.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Support\Packages\Laravel\Traits;
+
+trait {{ className }}
+{
+
+}

--- a/stubs/trait.support.stub
+++ b/stubs/trait.support.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace Support\Packages\Laravel\Traits;
+namespace Support\Traits;
 
 trait {{ className }}
 {

--- a/stubs/trait.support.stub
+++ b/stubs/trait.support.stub
@@ -1,8 +1,0 @@
-<?php
-
-namespace Support\Traits;
-
-trait {{ className }}
-{
-
-}

--- a/tests/Commands/MakeTraitCommandTest.php
+++ b/tests/Commands/MakeTraitCommandTest.php
@@ -3,21 +3,11 @@
 namespace Tests\Commands;
 
 test('can make trait', function () {
-    $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
-
-    expect(base_path() . '/src/Domain/Users/Traits/HasActivationCodeTrait.php')
-        ->toBeFile()
-        ->toMatchNamespaceAndClassName()
-        ->toPlaceholdersBeReplaced()
-        ->toFileContains('trait HasActivationCodeTrait');
-});
-
-test('can make support trait', function () {
-    $this->artisan('beyond:make:trait HasActivationCodeTrait --support');
+    $this->artisan('beyond:make:trait HasActivationCodeTrait');
 
     expect(base_path() . '/src/Support/Traits/HasActivationCodeTrait.php')
         ->toBeFile()
-        ->toPlaceholdersBeReplaced()
         ->toMatchNamespaceAndClassName()
+        ->toPlaceholdersBeReplaced()
         ->toFileContains('trait HasActivationCodeTrait');
 });

--- a/tests/Commands/MakeTraitCommandTest.php
+++ b/tests/Commands/MakeTraitCommandTest.php
@@ -5,7 +5,7 @@ namespace Tests\Commands;
 test('can make trait', function () {
     $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
 
-    expect(base_path() . '/src/App/Users/Traits/HasActivationCodeTrait.php')
+    expect(base_path() . '/src/Domain/Users/Traits/HasActivationCodeTrait.php')
         ->toBeFile()
         ->toPlaceholdersBeReplaced();
 });
@@ -21,9 +21,9 @@ test('can make support trait', function () {
 test('namespace is correct', function () {
     $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
 
-    $file = base_path() . '/src/App/Users/Traits/HasActivationCodeTrait.php';
+    $file = base_path() . '/src/Domain/Users/Traits/HasActivationCodeTrait.php';
     $content = file_get_contents($file);
-    expect($content)->toContain('namespace App\Users\Traits;');
+    expect($content)->toContain('namespace Domain\Users\Traits;');
 });
 
 test('support namespace is correct', function () {
@@ -37,7 +37,7 @@ test('support namespace is correct', function () {
 test('starts with trait', function () {
     $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
 
-    $file = base_path() . '/src/App/Users/Traits/HasActivationCodeTrait.php';
+    $file = base_path() . '/src/Domain/Users/Traits/HasActivationCodeTrait.php';
     $content = file_get_contents($file);
     expect($content)->toContain('trait HasActivationCodeTrait');
 });

--- a/tests/Commands/MakeTraitCommandTest.php
+++ b/tests/Commands/MakeTraitCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Commands;
+
+test('can make trait', function () {
+    $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
+
+    expect(base_path() . '/src/App/Users/Traits/HasActivationCodeTrait.php')
+        ->toBeFile()
+        ->toPlaceholdersBeReplaced();
+});
+
+test('can make support trait', function () {
+    $this->artisan('beyond:make:trait HasActivationCodeTrait --support');
+
+    expect(base_path() . '/src/Support/Packages/Laravel/Traits/HasActivationCodeTrait.php')
+        ->toBeFile()
+        ->toPlaceholdersBeReplaced();
+});
+
+test('namespace is correct', function () {
+    $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
+
+    $file = base_path() . '/src/App/Users/Traits/HasActivationCodeTrait.php';
+    $content = file_get_contents($file);
+    expect($content)->toContain('namespace App\Users\Traits;');
+});
+
+test('support namespace is correct', function () {
+    $this->artisan('beyond:make:trait HasActivationCodeTrait --support');
+
+    $file = base_path() . '/src/Support/Packages/Laravel/Traits/HasActivationCodeTrait.php';
+    $content = file_get_contents($file);
+    expect($content)->toContain('namespace Support\Packages\Laravel\Traits;');
+});
+
+test('starts with trait', function () {
+    $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
+
+    $file = base_path() . '/src/App/Users/Traits/HasActivationCodeTrait.php';
+    $content = file_get_contents($file);
+    expect($content)->toContain('trait HasActivationCodeTrait');
+});
+
+test('support starts with trait', function () {
+    $this->artisan('beyond:make:trait HasActivationCodeTrait --support');
+
+    $file = base_path() . '/src/Support/Packages/Laravel/Traits/HasActivationCodeTrait.php';
+    $content = file_get_contents($file);
+    expect($content)->toContain('trait HasActivationCodeTrait');
+});

--- a/tests/Commands/MakeTraitCommandTest.php
+++ b/tests/Commands/MakeTraitCommandTest.php
@@ -7,45 +7,17 @@ test('can make trait', function () {
 
     expect(base_path() . '/src/Domain/Users/Traits/HasActivationCodeTrait.php')
         ->toBeFile()
-        ->toPlaceholdersBeReplaced();
+        ->toMatchNamespaceAndClassName()
+        ->toPlaceholdersBeReplaced()
+        ->toFileContains('trait HasActivationCodeTrait');
 });
 
 test('can make support trait', function () {
     $this->artisan('beyond:make:trait HasActivationCodeTrait --support');
 
-    expect(base_path() . '/src/Support/Packages/Laravel/Traits/HasActivationCodeTrait.php')
+    expect(base_path() . '/src/Support/Traits/HasActivationCodeTrait.php')
         ->toBeFile()
-        ->toPlaceholdersBeReplaced();
-});
-
-test('namespace is correct', function () {
-    $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
-
-    $file = base_path() . '/src/Domain/Users/Traits/HasActivationCodeTrait.php';
-    $content = file_get_contents($file);
-    expect($content)->toContain('namespace Domain\Users\Traits;');
-});
-
-test('support namespace is correct', function () {
-    $this->artisan('beyond:make:trait HasActivationCodeTrait --support');
-
-    $file = base_path() . '/src/Support/Packages/Laravel/Traits/HasActivationCodeTrait.php';
-    $content = file_get_contents($file);
-    expect($content)->toContain('namespace Support\Packages\Laravel\Traits;');
-});
-
-test('starts with trait', function () {
-    $this->artisan('beyond:make:trait Users/HasActivationCodeTrait');
-
-    $file = base_path() . '/src/Domain/Users/Traits/HasActivationCodeTrait.php';
-    $content = file_get_contents($file);
-    expect($content)->toContain('trait HasActivationCodeTrait');
-});
-
-test('support starts with trait', function () {
-    $this->artisan('beyond:make:trait HasActivationCodeTrait --support');
-
-    $file = base_path() . '/src/Support/Packages/Laravel/Traits/HasActivationCodeTrait.php';
-    $content = file_get_contents($file);
-    expect($content)->toContain('trait HasActivationCodeTrait');
+        ->toPlaceholdersBeReplaced()
+        ->toMatchNamespaceAndClassName()
+        ->toFileContains('trait HasActivationCodeTrait');
 });


### PR DESCRIPTION
As https://github.com/regnerisch/laravel-beyond/issues/54 requested, I have created `beyond:make:trait` command.

The trait is created in `Domain\XXX\Traits` namespace by default.
You can add `--support` flag to create the trait in `Support\Packages\Laravel\Traits` namespace.