### PR TITLE
use spatie/laravel-data package as spatie/data-transfer-object is depricated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,9 @@
     "require-dev": {
         "pestphp/pest": "^1.21",
         "orchestra/testbench": "^7.6",
-        "spatie/data-transfer-object": "^3.8",
         "spatie/laravel-query-builder": "^5.0",
-        "spatie/laravel-queueable-action": "^2.14"
+        "spatie/laravel-queueable-action": "^2.14",
+        "spatie/laravel-data": "^2.0"
     },
     "config": {
         "allow-plugins": {

--- a/src/Commands/MakeDataTransferObjectCommand.php
+++ b/src/Commands/MakeDataTransferObjectCommand.php
@@ -11,7 +11,7 @@ class MakeDataTransferObjectCommand extends BaseCommand
     protected $description = 'Make a new data transfer object';
 
     protected array $requiredPackages = [
-        'spatie/data-transfer-object',
+        'spatie/laravel-data',
     ];
 
     public function handle(): void

--- a/stubs/data-transfer-object.stub
+++ b/stubs/data-transfer-object.stub
@@ -2,9 +2,11 @@
 
 namespace Domain\{{ namespace }}\DataTransferObjects;
 
-use Spatie\DataTransferObject\DataTransferObject;
+use Spatie\LaravelData\Data;
 
-class {{ className }} extends DataTransferObject
+class {{ className }} extends Data
 {
-    //
+    public function __construct(
+    ) {
+    }
 }

--- a/tests/Commands/MakeDataTransferObjectCommandTest.php
+++ b/tests/Commands/MakeDataTransferObjectCommandTest.php
@@ -7,7 +7,7 @@ use AkrilliA\LaravelBeyond\Contracts\Composer as ComposerContract;
 test('can make dto', function () {
     $composer = $this->app->make(ComposerContract::class);
 
-    $composer->setPackages(['spatie/data-transfer-object']);
+    $composer->setPackages(['spatie/laravel-data']);
 
     $this->artisan('beyond:make:dto User/UserData');
 


### PR DESCRIPTION
Hi,
Spatie data-transfer-object package is deprecated so it is better to migrate over spatie laravel-data as they recommended.
Thanks!